### PR TITLE
add a docker image for easy website tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM ruby
+MAINTAINER bitard [DOT] michael [AT] gmail [DOT] com
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates apt-transport-https curl libfontconfig sudo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# ADD USER ct
+RUN export uid=1000 gid=1000 user=ct && \
+    mkdir -p /home/ct && \
+    echo "${user}:x:${uid}:${gid}:${user},,,:/home/${user}:/bin/bash" >> /etc/passwd && \
+    echo "${user}:x:${uid}:" >> /etc/group && \
+    echo "${user} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${user} && \
+    chmod 0440 /etc/sudoers.d/${user} && \
+    chown ${uid}:${gid} -R /home/${user}
+
+ADD nodesource.list /etc/apt/sources.list.d/nodesource.list
+
+RUN curl -k -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    apt-get update && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN npm install -g gulp && \
+    npm install -g grunt && \
+    npm install -g grunt-cli && \
+    npm install -g bower
+
+RUN gem install jekyll rdiscount kramdown
+
+VOLUME /src
+EXPOSE 9002
+
+WORKDIR /src
+USER ct
+ADD run /run.sh
+CMD ["/run.sh"]

--- a/docker/nodesource.list
+++ b/docker/nodesource.list
@@ -1,0 +1,2 @@
+deb https://deb.nodesource.com/node jessie main
+deb-src https://deb.nodesource.com/node jessie main

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+npm install
+export CI=true
+bower install
+grunt server


### PR DESCRIPTION
at the repo root:
- docker build -t ct-website docker/
- docker run -p 9002:9002 -v $PWD:/src:rw -ti ct-website

When you have a trusted build, it will be something like:
- docker run -p 9002:9002 -v $PWD:/src:rw -ti codetroopers/ct-website
  And the build step will be useless
