### PR TITLE
[docker] Don't use a non tagged version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:2.2.0-wheezy
 MAINTAINER bitard [DOT] michael [AT] gmail [DOT] com
 
 RUN apt-get update && \

--- a/docker/nodesource.list
+++ b/docker/nodesource.list
@@ -1,2 +1,2 @@
-deb https://deb.nodesource.com/node jessie main
-deb-src https://deb.nodesource.com/node jessie main
+deb https://deb.nodesource.com/node wheezy main
+deb-src https://deb.nodesource.com/node wheezy main


### PR DESCRIPTION
use FROM ruby:wheezy-2.2.0
