### PR TITLE
feat(stripCommentsFromCSS): remove comments from generated css

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 **For websites built with Hugo and Webpack**
 
-
 ## Usage (run with Docker)
 
 ```bash

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -14,8 +14,8 @@
         <p class="gradient">Nous sommes une agence spécialisée dans le développement logiciel et la conception
             d’applications mobiles
             sur-mesure.</p>
-        <p>Analyse pour de grands groupes, développement natif multisupport pour des start-ups innovantes… Les sept
-            membres de notre structure s’engagent dans des suivis complets, rigoureux, au plus près des différentes
+        <p>Analyse pour de grands groupes, développement natif multisupport pour des start-ups innovantes…
+            Les membres de notre structure s’engagent dans des suivis complets, rigoureux, au plus près des différentes
             phases de vos projets informatiques.
         </p>
     </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -34,7 +34,7 @@ var initCountUp = function(){
     scrollMonitor.create(el).enterViewport(function () {
         var targetValue = this.watchItem.getAttribute('data-count');
         if (this.watchItem.getAttribute('data-random')) {
-            targetValue = Math.ceil(Math.random()*64);
+            targetValue = Math.ceil(Math.random()*32) + 32;
         }
         var demo = new CountUp(this.watchItem, 0, targetValue, 0, 3, options);
       if (!demo.error) {

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -24,7 +24,7 @@ export default function() {
     new SuppressChunksPlugin(['img', 'html'])
   ];
   const cssLoaders = [
-    { loader: 'css-loader', options: Object.assign({ minimize: true, sourceMap: true }, cssNano) },
+    { loader: 'css-loader', options: Object.assign({ minimize: {discardComments: { removeAll: true }}, sourceMap: true }, cssNano) },
     { loader: 'postcss-loader', options: Object.assign({ sourceMap: true }, postCSS) },
     { loader: 'resolve-url-loader', options: { sourceMap: true } },
     { loader: 'sass-loader', options: { sourceMap: true } }


### PR DESCRIPTION
Cloudflare is messing our CSS when it contains comments, it cut the file halfway.
We strip them at build time to be able to enable Cloudflare speed up again